### PR TITLE
登録したら一覧画面に遷移できるようになりました

### DIFF
--- a/ViewModels/BookListViewModel.cs
+++ b/ViewModels/BookListViewModel.cs
@@ -20,7 +20,7 @@ namespace LifeBooks.ViewModels
             LoadBooksAsync();
         }
 
-        private async Task LoadBooksAsync()
+        public async Task LoadBooksAsync()
         {
             try
             {

--- a/ViewModels/BookRegistrationViewModel.cs
+++ b/ViewModels/BookRegistrationViewModel.cs
@@ -35,6 +35,10 @@ public partial class BookRegistrationViewModel : ObservableObject
         _bookRepository = new BookRepository(dbPath);
     }
 
+    /// <summary>
+    /// 本の登録
+    /// </summary>
+    /// <returns></returns>
     [RelayCommand]
     private async Task Register()
     {
@@ -46,6 +50,15 @@ public partial class BookRegistrationViewModel : ObservableObject
         RegisteredBook.Description = Description;
         await _bookRepository.AddBookAsync(RegisteredBook);
         RegistrationMessage = "登録が完了しました。";
-
+        await Shell.Current.GoToAsync("..");
+    }
+    /// <summary>
+    /// 一覧画面に戻る
+    /// </summary>
+    /// <returns></returns>
+    [RelayCommand]
+    private async Task GoToListPage()
+    {
+        await Shell.Current.GoToAsync("..");
     }
 }

--- a/Views/BookListPage.xaml
+++ b/Views/BookListPage.xaml
@@ -2,7 +2,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewModels="clr-namespace:LifeBooks.ViewModels"
              x:Class="LifeBooks.Views.BookListPage"
-             Title="Book List">
+             Title="本棚"
+             Appearing="BookListPage_Appearing">
 
     <ContentPage.BindingContext>
         <viewModels:BookListViewModel />
@@ -26,8 +27,7 @@
         </Grid.RowDefinitions>
 
         <VerticalStackLayout Grid.Row="0" Padding="20">
-            <Button Text="本の登録" Clicked="GoToRegistrationPage" />
-            <Label Text="本棚" FontSize="Header" VerticalOptions="Center" HorizontalOptions="Center" />
+            <Button Text="本を登録する" Clicked="GoToRegistrationPage" />
         </VerticalStackLayout>
 
         <ScrollView Grid.Row="1">

--- a/Views/BookListPage.xaml.cs
+++ b/Views/BookListPage.xaml.cs
@@ -17,4 +17,9 @@ public partial class BookListPage : ContentPage
     {
         await Shell.Current.GoToAsync(nameof(BookRegistrationPage));
     }
+    private void BookListPage_Appearing(object sender, EventArgs e)
+    {
+        var viewModel = (BookListViewModel)BindingContext;
+        viewModel.LoadBooksAsync();
+    }
 }

--- a/Views/BookRegistrationPage.xaml
+++ b/Views/BookRegistrationPage.xaml
@@ -7,15 +7,22 @@
     <ContentPage.BindingContext>
         <viewModels:BookRegistrationViewModel />
     </ContentPage.BindingContext>
-
     <VerticalStackLayout Padding="20" Spacing="10">
+        <Button Text="一覧ページへ" Command="{Binding GoToListPageCommand}"/>
         <Entry Placeholder="書籍名" Text="{Binding Title}" />
-        <Entry Placeholder="著者名" Text="{Binding Author}" />
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Entry Placeholder="著者名" Text="{Binding Author}" Grid.Column="0"/>
+            <Entry Placeholder="出版社名" Text="{Binding Publisher}" Grid.Column="1"/>
+        </Grid>
         <!--<Entry Placeholder="ISBN" Text="{Binding ISBN}" Keyboard="Numeric" />-->
-        <Entry Placeholder="出版社名" Text="{Binding Publisher}" />
         <Entry Placeholder="ジャンル" Text="{Binding Genre}" />
         <Editor Placeholder="感想やメモ" Text="{Binding Description}" HeightRequest="100" />
 
         <Button Text="登録" Command="{Binding RegisterCommand}" />
+
     </VerticalStackLayout>
 </ContentPage>


### PR DESCRIPTION
- 登録したら一覧画面に自動遷移できる
- 登録画面から一覧画面に遷移できる
- 一覧画面でのウィンドウ上部の表記変更（BookList→本棚）によりわかりやすくなった
- 上記の表記変更に伴い，本の一覧リスト上部にあったタイトル「本棚」を削除したことでわかりやすくなった
- 登録画面で，著者名と出版社名の入力欄を横に並べることでスッキリした見た目になりました